### PR TITLE
Fix residue calculation for small datasets

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -74,7 +74,7 @@ class DatasetIterater(object):
         self.batches = batches
         self.n_batches = len(batches) // batch_size
         self.residue = False  # 记录batch数量是否为整数
-        if len(batches) % self.n_batches != 0:
+        if len(batches) % batch_size != 0:
             self.residue = True
         self.index = 0
         self.device = device

--- a/utils_fasttext.py
+++ b/utils_fasttext.py
@@ -92,8 +92,8 @@ class DatasetIterater(object):
         self.batch_size = batch_size
         self.batches = batches
         self.n_batches = len(batches) // batch_size
-        self.residue = False  # 记录batch数量是否为整数 
-        if len(batches) % self.n_batches != 0:
+        self.residue = False  # 记录batch数量是否为整数
+        if len(batches) % batch_size != 0:
             self.residue = True
         self.index = 0
         self.device = device


### PR DESCRIPTION
## Summary
- avoid ZeroDivisionError when dataset is smaller than batch size
- update both dataset iterators in utils modules

## Testing
- `python -m py_compile utils.py utils_fasttext.py train_eval.py run.py models/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469de4889c83308aa92826fed06560