### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project Overview
+
+Chinese text classification using PyTorch. 7 models (TextCNN, TextRNN, TextRNN_Att, TextRCNN, FastText, DPCNN, Transformer) trained on THUCNews dataset (200k Chinese news titles, 10 categories).
+
+### Running Models
+
+```bash
+python3 run.py --model TextCNN          # or TextRNN, TextRNN_Att, TextRCNN, DPCNN, Transformer
+python3 run.py --model FastText --embedding random   # FastText uses random embeddings
+```
+
+See `README.md` for full usage and expected accuracy per model.
+
+### Key Notes
+
+- **No GPU required.** Training auto-falls back to CPU. CPU training for TextCNN takes ~12 minutes on the Cloud VM.
+- **No `requirements.txt` in repo.** Dependencies: `torch` (CPU), `tqdm`, `scikit-learn`, `tensorboardX`, `numpy`. Install via: `pip install torch --index-url https://download.pytorch.org/whl/cpu tqdm scikit-learn tensorboardX numpy`
+- **No linter or test suite exists** in this repo. Validation is done by running training and checking accuracy against README benchmarks.
+- **Use `python3 -u`** (unbuffered) when piping output to `tee` or logs, otherwise training progress will not appear until the buffer flushes.
+- **Early stopping**: training auto-stops if validation loss doesn't improve for 1000 batches (`config.require_improvement`).
+- **TensorBoard** logs are written to `THUCNews/log/`. Optionally run `tensorboard --logdir THUCNews/log/` to visualize.
+- **Model checkpoints** are saved to `THUCNews/saved_dict/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `AGENTS.md` with Cursor Cloud specific development instructions for this Chinese text classification project.

### What's included

- Project overview and model training commands
- Key development notes (CPU-only training, no linter/test suite, unbuffered output tip, early stopping behavior)
- Dependency installation reference

### Environment verification

Successfully trained TextCNN model end-to-end on CPU, achieving **91.09% test accuracy** (expected ~91.22% per README).

Training log:
[textcnn_training_output.log](https://cursor.com/agents/bc-1a88c149-9109-43b3-b7f4-4becee05b9ff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftextcnn_training_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a88c149-9109-43b3-b7f4-4becee05b9ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a88c149-9109-43b3-b7f4-4becee05b9ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

